### PR TITLE
Add tests for NotFound component to verify rendering and navigation behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # next.js
 /.next/
 /out/
+.swc/
 
 # production
 /build

--- a/app/__tests__/not-found.test.tsx
+++ b/app/__tests__/not-found.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NotFound from '../not-found';
+import { useRouter } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn()
+}));
+
+describe('NotFound', () => {
+  const backMock = jest.fn();
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ back: backMock });
+    backMock.mockClear();
+  });
+
+  it('renders 404 and OOPS! Page Not Found', () => {
+    render(<NotFound />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('OOPS! Page Not Found')).toBeInTheDocument();
+  });
+
+  it('renders helpful links', () => {
+    render(<NotFound />);
+    expect(screen.getByText('Go Back')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('calls router.back when Go Back is clicked', () => {
+    render(<NotFound />);
+    fireEvent.click(screen.getByText('Go Back'));
+    expect(backMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This pull request adds unit tests for the `NotFound` component to ensure proper rendering and functionality.

### Added tests for `NotFound` component:

* `app/__tests__/not-found.test.tsx`: Introduced a test suite for the `NotFound` component using Jest and React Testing Library. The tests verify:
  - The component renders the "404" and "OOPS! Page Not Found" messages.
  - The presence of helpful links, such as "Go Back" and "Home."
  - The "Go Back" button triggers the `router.back` function when clicked.