### PR TITLE
fix: specify npm as the package ecosystem in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to specify the package ecosystem for dependency updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R8): Changed the `package-ecosystem` value from an empty string to `"npm"` to explicitly define the package manager used for dependency updates.