### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yunji0387/next-admin-system/security/code-scanning/1](https://github.com/yunji0387/next-admin-system/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code, installs dependencies, and runs tests (all read-only operations), the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `test` job). The best practice is to set it at the workflow level unless a job needs different permissions. The change should be made by adding the following block after the `name:` field and before the `on:` field:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
